### PR TITLE
Use correct constant for UIView animation options

### DIFF
--- a/Source/UIViewController+MJPopupViewController.m
+++ b/Source/UIViewController+MJPopupViewController.m
@@ -191,7 +191,7 @@
     // Set starting properties
     popupView.frame = popupStartRect;
     popupView.alpha = 1.0f;
-    [UIView animateWithDuration:kPopupModalAnimationDuration delay:0.0f options:UIViewAnimationCurveEaseOut animations:^{
+    [UIView animateWithDuration:kPopupModalAnimationDuration delay:0.0f options:UIViewAnimationOptionCurveEaseOut animations:^{
         backgroundView.alpha = 1.0f;
         popupView.frame = popupEndRect;
     } completion:^(BOOL finished) {
@@ -232,7 +232,7 @@
             break;
     }
     
-    [UIView animateWithDuration:kPopupModalAnimationDuration delay:0.0f options:UIViewAnimationCurveEaseIn animations:^{
+    [UIView animateWithDuration:kPopupModalAnimationDuration delay:0.0f options:UIViewAnimationOptionCurveEaseIn animations:^{
         popupView.frame = popupEndRect;
         backgroundView.alpha = 0.0f;
     } completion:^(BOOL finished) {


### PR DESCRIPTION
`UIView` `-animateWithDuration:options:animations:completion:` requires options to be of the enum type `UIViewAnimationOptions`. Replaced the wrong constants `UIViewAnimationCurveEaseIn` and `UIViewAnimationCurveEaseOut` with `UIViewAnimationOptionCurveEaseIn` and `UIViewAnimationOptionCurveEaseOut` respectively. This fixed an error that caused the popups to stack when rapidly dismissing and showing them.
