### PR TITLE
Improved alpha animation of popUpView

### DIFF
--- a/Source/UIViewController+MJPopupViewController.m
+++ b/Source/UIViewController+MJPopupViewController.m
@@ -103,6 +103,8 @@ static void * const keypath = (void*)&keypath;
     popupView.layer.shadowOffset = CGSizeMake(5, 5);
     popupView.layer.shadowRadius = 5;
     popupView.layer.shadowOpacity = 0.5;
+    popupView.layer.shouldRasterize = YES;
+    popupView.layer.rasterizationScale = [[UIScreen mainScreen] scale];
     
     // Add semi overlay
     UIView *overlayView = [[UIView alloc] initWithFrame:sourceView.bounds];


### PR DESCRIPTION
Previous alpha animation made visible shadows, buttons and other possible subviews used to compound the popUpView: 

![iOS Simulator Screen shot Apr 3 2013 10 22 55 PM](https://f.cloud.github.com/assets/612990/336032/b0ce12c4-9c9c-11e2-95b4-5723915a4860.png)

By rasterizing popUpView, all its subviews fade as a single object, resulting in a smoother alpha animation.

![iOS Simulator Screen shot Apr 3 2013 10 23 37 PM](https://f.cloud.github.com/assets/612990/336031/a8607960-9c9c-11e2-8981-3cea24f218a3.png)
