### PR TITLE
Add animation type to support Popup below Statusbar/Navbar

### DIFF
--- a/MJPopupViewControllerDemo/MJPopupViewControllerDemo/MJViewController.m
+++ b/MJPopupViewControllerDemo/MJPopupViewControllerDemo/MJViewController.m
@@ -34,6 +34,8 @@
                       @"slide - left to right",
                       @"slide - right to left",
                       @"slide - right to right",
+                      @"slide - below navbar to top",
+                      @"slide - below navbar to bottom",
                       nil];
         actions = [NSArray arrayWithObjects:
                    @"popup with user interaction",

--- a/Source/UIViewController+MJPopupViewController.h
+++ b/Source/UIViewController+MJPopupViewController.h
@@ -20,6 +20,9 @@ typedef enum {
     MJPopupViewAnimationSlideLeftRight,
     MJPopupViewAnimationSlideRightLeft,
     MJPopupViewAnimationSlideRightRight,
+  
+    MJPopupViewAnimationSlideBelowNavbarTop,
+    MJPopupViewAnimationSlideBelowNavbarBottom,
 } MJPopupViewAnimation;
 
 @interface UIViewController (MJPopupViewController)

--- a/Source/UIViewController+MJPopupViewController.m
+++ b/Source/UIViewController+MJPopupViewController.m
@@ -69,6 +69,9 @@ static void * const keypath = (void*)&keypath;
     UIView *overlayView = [sourceView viewWithTag:kMJOverlayViewTag];
     
     switch (animationType) {
+        case MJPopupViewAnimationSlideBelowNavbarTop:
+        case MJPopupViewAnimationSlideBelowNavbarBottom:
+
         case MJPopupViewAnimationSlideBottomTop:
         case MJPopupViewAnimationSlideBottomBottom:
         case MJPopupViewAnimationSlideTopTop:
@@ -142,6 +145,9 @@ static void * const keypath = (void*)&keypath;
     
     [dismissButton addTarget:self action:@selector(dismissPopupViewControllerWithanimation:) forControlEvents:UIControlEventTouchUpInside];
     switch (animationType) {
+        case MJPopupViewAnimationSlideBelowNavbarTop:
+        case MJPopupViewAnimationSlideBelowNavbarBottom:
+
         case MJPopupViewAnimationSlideBottomTop:
         case MJPopupViewAnimationSlideBottomBottom:
         case MJPopupViewAnimationSlideTopTop:
@@ -176,6 +182,9 @@ static void * const keypath = (void*)&keypath;
     if ([sender isKindOfClass:[UIButton class]]) {
         UIButton* dismissButton = sender;
         switch (dismissButton.tag) {
+            case MJPopupViewAnimationSlideBelowNavbarTop:
+            case MJPopupViewAnimationSlideBelowNavbarBottom:
+
             case MJPopupViewAnimationSlideBottomTop:
             case MJPopupViewAnimationSlideBottomBottom:
             case MJPopupViewAnimationSlideTopTop:
@@ -223,7 +232,8 @@ static void * const keypath = (void*)&keypath;
                                         popupSize.width,
                                         popupSize.height);
             break;
-            
+        case MJPopupViewAnimationSlideBelowNavbarTop:
+        case MJPopupViewAnimationSlideBelowNavbarBottom:
         case MJPopupViewAnimationSlideTopTop:
         case MJPopupViewAnimationSlideTopBottom:
             popupStartRect = CGRectMake((sourceSize.width - popupSize.width) / 2,
@@ -244,6 +254,17 @@ static void * const keypath = (void*)&keypath;
                                      popupSize.width,
                                      popupSize.height);
     
+    // both "BelowNavbar" types comes from top
+    // if navigationController is nil, popup stay below statusBar
+    if(animationType==MJPopupViewAnimationSlideBelowNavbarBottom||animationType==MJPopupViewAnimationSlideBelowNavbarTop){
+      static int navBarOffset = 10;
+
+      popupEndRect = CGRectMake((sourceSize.width - popupSize.width) / 2,
+                                (self.navigationController.navigationBar.frame.size.height + [UIApplication sharedApplication].statusBarFrame.size.height) + navBarOffset,
+                                popupSize.width,
+                                popupSize.height);
+    }
+
     // Set starting properties
     popupView.frame = popupStartRect;
     popupView.alpha = 1.0f;
@@ -263,6 +284,7 @@ static void * const keypath = (void*)&keypath;
     CGSize popupSize = popupView.bounds.size;
     CGRect popupEndRect;
     switch (animationType) {
+        case MJPopupViewAnimationSlideBelowNavbarTop:
         case MJPopupViewAnimationSlideBottomTop:
         case MJPopupViewAnimationSlideTopTop:
             popupEndRect = CGRectMake((sourceSize.width - popupSize.width) / 2,
@@ -270,6 +292,7 @@ static void * const keypath = (void*)&keypath;
                                       popupSize.width,
                                       popupSize.height);
             break;
+        case MJPopupViewAnimationSlideBelowNavbarBottom:
         case MJPopupViewAnimationSlideBottomBottom:
         case MJPopupViewAnimationSlideTopBottom:
             popupEndRect = CGRectMake((sourceSize.width - popupSize.width) / 2,


### PR DESCRIPTION
To prevent keyboard to overlay the Popup with some widgets, like UITextView, UITextField, I created two options to keep it below Navbar or only Statusbar (when the UIViewController isn't embedded in a UINavigationController)
