### PR TITLE
fixed #16

### DIFF
--- a/MJPopupViewControllerDemo/MJPopupViewControllerDemo/MJSecondDetailViewController.h
+++ b/MJPopupViewControllerDemo/MJPopupViewControllerDemo/MJSecondDetailViewController.h
@@ -8,18 +8,6 @@
 
 #import <UIKit/UIKit.h>
 
-@protocol MJSecondPopupDelegate;
-
-
 @interface MJSecondDetailViewController : UIViewController
 
-@property (assign, nonatomic) id <MJSecondPopupDelegate>delegate;
-
-@end
-
-
-
-@protocol MJSecondPopupDelegate<NSObject>
-@optional
-- (void)cancelButtonClicked:(MJSecondDetailViewController*)secondDetailViewController;
 @end

--- a/MJPopupViewControllerDemo/MJPopupViewControllerDemo/MJSecondDetailViewController.m
+++ b/MJPopupViewControllerDemo/MJPopupViewControllerDemo/MJSecondDetailViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "MJSecondDetailViewController.h"
+#import "UIViewController+MJPopupViewController.h"
 
 @interface MJSecondDetailViewController ()
 
@@ -14,14 +15,9 @@
 
 @implementation MJSecondDetailViewController
 
-@synthesize delegate;
+- (IBAction)dismissPopup:(id)sender {
+    [self dismissPopupViewControllerWithanimationType:MJPopupViewAnimationFade];
 
-
-- (IBAction)closePopup:(id)sender
-{
-    if (self.delegate && [self.delegate respondsToSelector:@selector(cancelButtonClicked:)]) {
-        [self.delegate cancelButtonClicked:self];
-    }
 }
 
 @end

--- a/MJPopupViewControllerDemo/MJPopupViewControllerDemo/MJSecondDetailViewController.xib
+++ b/MJPopupViewControllerDemo/MJPopupViewControllerDemo/MJSecondDetailViewController.xib
@@ -1,175 +1,32 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1296</int>
-		<string key="IBDocument.SystemVersion">11E53</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2182</string>
-		<string key="IBDocument.AppKitVersion">1138.47</string>
-		<string key="IBDocument.HIToolboxVersion">569.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">1181</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBProxyObject</string>
-			<string>IBUIView</string>
-			<string>IBUIButton</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<object class="IBProxyObject" id="372490531">
-				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBProxyObject" id="975951072">
-				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBUIView" id="191373211">
-				<reference key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="IBUIButton" id="841056855">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{39, 81}, {122, 37}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentHorizontalAlignment">0</int>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">close popup</string>
-						<object class="NSColor" key="IBUIHighlightedTitleColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MQA</bytes>
-						</object>
-						<object class="NSColor" key="IBUINormalTitleColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
-						</object>
-						<object class="NSColor" key="IBUINormalTitleShadowColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MC41AA</bytes>
-						</object>
-						<object class="IBUIFontDescription" key="IBUIFontDescription">
-							<int key="type">2</int>
-							<double key="pointSize">15</double>
-						</object>
-						<object class="NSFont" key="IBUIFont">
-							<string key="NSName">Helvetica-Bold</string>
-							<double key="NSSize">15</double>
-							<int key="NSfFlags">16</int>
-						</object>
-					</object>
-				</array>
-				<string key="NSFrameSize">{200, 200}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="841056855"/>
-				<object class="NSColor" key="IBUIBackgroundColor">
-					<int key="NSColorSpace">1</int>
-					<bytes key="NSRGB">MC4xODg0NTEyMTE0IDAuNzAxMjMxNjY0NSAwLjIxMzY1NjIwOTEAA</bytes>
-				</object>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">view</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="191373211"/>
-					</object>
-					<int key="connectionID">3</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">closePopup:</string>
-						<reference key="source" ref="841056855"/>
-						<reference key="destination" ref="372490531"/>
-						<int key="IBEventType">7</int>
-					</object>
-					<int key="connectionID">5</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="1000"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1</int>
-						<reference key="object" ref="191373211"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="841056855"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="372490531"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="975951072"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">4</int>
-						<reference key="object" ref="841056855"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.CustomClassName">MJSecondDetailViewController</string>
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="-2.CustomClassName">UIResponder</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">5</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">MJSecondDetailViewController</string>
-					<string key="superclassName">UIViewController</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/MJSecondDetailViewController.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
-			<real value="1296" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">1181</string>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="5056" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+    <dependencies>
+        <deployment defaultVersion="1024" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MJSecondDetailViewController">
+            <connections>
+                <outlet property="view" destination="1" id="3"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="4">
+                    <rect key="frame" x="39" y="81" width="122" height="37"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="dismiss popup">
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="dismissPopup:" destination="-1" eventType="touchUpInside" id="M1k-Re-qWt"/>
+                    </connections>
+                </button>
+            </subviews>
+            <color key="backgroundColor" red="0.18845121140000001" green="0.70123166449999996" blue="0.21365620909999999" alpha="1" colorSpace="calibratedRGB"/>
+        </view>
+    </objects>
+</document>

--- a/MJPopupViewControllerDemo/MJPopupViewControllerDemo/MJViewController.m
+++ b/MJPopupViewControllerDemo/MJPopupViewControllerDemo/MJViewController.m
@@ -11,7 +11,7 @@
 #import "MJDetailViewController.h"
 #import "MJSecondDetailViewController.h"
 
-@interface MJViewController () <MJSecondPopupDelegate>{
+@interface MJViewController () {
     NSArray *actions;
     NSArray *animations;
 }
@@ -175,7 +175,6 @@
             
         default: {
             MJSecondDetailViewController *secondDetailViewController = [[MJSecondDetailViewController alloc] initWithNibName:@"MJSecondDetailViewController" bundle:nil];
-            secondDetailViewController.delegate = self;
             [self presentPopupViewController:secondDetailViewController animationType:MJPopupViewAnimationFade];
             
         }

--- a/Source/UIViewController+MJPopupViewController.h
+++ b/Source/UIViewController+MJPopupViewController.h
@@ -25,6 +25,7 @@ typedef enum {
 @interface UIViewController (MJPopupViewController)
 
 @property (nonatomic, retain) UIViewController *mj_popupViewController;
+@property (nonatomic, retain) UIViewController *mj_popupingViewController;
 @property (nonatomic, retain) MJPopupBackgroundView *mj_popupBackgroundView;
 
 - (void)presentPopupViewController:(UIViewController*)popupViewController animationType:(MJPopupViewAnimation)animationType;

--- a/Source/UIViewController+MJPopupViewController.m
+++ b/Source/UIViewController+MJPopupViewController.m
@@ -13,6 +13,7 @@
 
 #define kPopupModalAnimationDuration 0.35
 #define kMJPopupViewController @"kMJPopupViewController"
+#define kMJPopupingViewController @"kMJPopupingViewController"
 #define kMJPopupBackgroundView @"kMJPopupBackgroundView"
 #define kMJSourceViewTag 23941
 #define kMJPopupViewTag 23942
@@ -42,6 +43,14 @@ static void * const keypath = (void*)&keypath;
     
 }
 
+- (UIViewController *)mj_popupingViewController {
+    return objc_getAssociatedObject(self, kMJPopupingViewController);
+}
+
+- (void)setMj_popupingViewController:(UIViewController *)mj_popupingViewController {
+    objc_setAssociatedObject(self, kMJPopupingViewController, mj_popupingViewController, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 - (MJPopupBackgroundView*)mj_popupBackgroundView {
     return objc_getAssociatedObject(self, kMJPopupBackgroundView);
 }
@@ -54,6 +63,7 @@ static void * const keypath = (void*)&keypath;
 - (void)presentPopupViewController:(UIViewController*)popupViewController animationType:(MJPopupViewAnimation)animationType dismissed:(void(^)(void))dismissed
 {
     self.mj_popupViewController = popupViewController;
+    popupViewController.mj_popupingViewController = self;
     [self presentPopupView:popupViewController.view animationType:animationType dismissed:dismissed];
 }
 
@@ -68,6 +78,8 @@ static void * const keypath = (void*)&keypath;
     UIView *popupView = [sourceView viewWithTag:kMJPopupViewTag];
     UIView *overlayView = [sourceView viewWithTag:kMJOverlayViewTag];
     
+    UIViewController *popupingViewController = self.mj_popupingViewController ?: self;
+    
     switch (animationType) {
         case MJPopupViewAnimationSlideBottomTop:
         case MJPopupViewAnimationSlideBottomBottom:
@@ -77,11 +89,11 @@ static void * const keypath = (void*)&keypath;
         case MJPopupViewAnimationSlideLeftRight:
         case MJPopupViewAnimationSlideRightLeft:
         case MJPopupViewAnimationSlideRightRight:
-            [self slideViewOut:popupView sourceView:sourceView overlayView:overlayView withAnimationType:animationType];
+            [popupingViewController slideViewOut:popupView sourceView:sourceView overlayView:overlayView withAnimationType:animationType];
             break;
             
         default:
-            [self fadeViewOut:popupView sourceView:sourceView overlayView:overlayView];
+            [popupingViewController fadeViewOut:popupView sourceView:sourceView overlayView:overlayView];
             break;
     }
 }
@@ -163,7 +175,7 @@ static void * const keypath = (void*)&keypath;
 }
 
 -(UIView*)topView {
-    UIViewController *recentView = self;
+    UIViewController *recentView = self.mj_popupingViewController ?: self;
     
     while (recentView.parentViewController != nil) {
         recentView = recentView.parentViewController;


### PR DESCRIPTION
fixed
[#16](https://github.com/martinjuhasz/MJPopupViewController/issues/16)
overlay did not removed when
`dismissPopupViewControllerWithanimationType:` called
