### PR TITLE
Fix tap-too-soon crash bug.

### DIFF
--- a/Source/UIViewController+MJPopupViewController.m
+++ b/Source/UIViewController+MJPopupViewController.m
@@ -68,6 +68,10 @@ static void * const keypath = (void*)&keypath;
     UIView *popupView = [sourceView viewWithTag:kMJPopupViewTag];
     UIView *overlayView = [sourceView viewWithTag:kMJOverlayViewTag];
     
+    if ((sourceView == nil) || (popupView == nil) || (overlayView == nil)) {
+        return;
+    }
+    
     switch (animationType) {
         case MJPopupViewAnimationSlideBottomTop:
         case MJPopupViewAnimationSlideBottomBottom:


### PR DESCRIPTION
Per the issue I posted earlier today... Reasonably sure this was the root of the issue -- sometimes the dismiss method got called when the views weren't properly in place.  Doing a null check on the three views seems to remedy the problem.
