### PR TITLE
Add the ability keep Popup on screen

### DIFF
--- a/MJPopupViewController.podspec
+++ b/MJPopupViewController.podspec
@@ -1,12 +1,13 @@
 Pod::Spec.new do |s|
-  s.name         = "MJPopupViewController"
-  s.version      = "0.4"
-  s.summary      = "A UIViewController Category to display a ViewController as a popup with different transition effects."
-  s.homepage     = "https://github.com/martinjuhasz/MJPopupViewController"
-  s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
-  s.author       = 'martinjuhasz'
-  s.source       = { :git => "https://github.com/martinjuhasz/MJPopupViewController.git", :tag => "v0.4" }
-  s.platform     = :ios, '4.0'
+  s.name     = 'MJPopupViewController'
+  s.version  = '0.4.1'
+  s.summary  = 'A UIViewController Category to display a ViewController as a popup with different transition effects.'
+  s.homepage = 'https://github.com/martinjuhasz/MJPopupViewController'
+  s.license  = { :type => 'MIT', :file => 'LICENSE.txt' }
+  s.authors  = { 'martinjuhasz' }
+  s.source   = { :git => 'https://github.com/martinjuhasz/MJPopupViewController.git', :tag => 'v0.4.1' }
+  s.ios.deployment_target = '4.0'
+  
   s.source_files = 'Source/*.{h,m}'
   s.frameworks = 'QuartzCore'
   s.requires_arc = true

--- a/Source/UIViewController+MJPopupViewController.h
+++ b/Source/UIViewController+MJPopupViewController.h
@@ -26,6 +26,7 @@ typedef enum {
 
 @property (nonatomic, retain) UIViewController *mj_popupViewController;
 @property (nonatomic, retain) MJPopupBackgroundView *mj_popupBackgroundView;
+@property (nonatomic, assign) BOOL keepOnTouchOutside;
 
 - (void)presentPopupViewController:(UIViewController*)popupViewController animationType:(MJPopupViewAnimation)animationType;
 - (void)presentPopupViewController:(UIViewController*)popupViewController animationType:(MJPopupViewAnimation)animationType dismissed:(void(^)(void))dismissed;

--- a/Source/UIViewController+MJPopupViewController.m
+++ b/Source/UIViewController+MJPopupViewController.m
@@ -14,6 +14,7 @@
 #define kPopupModalAnimationDuration 0.35
 #define kMJPopupViewController @"kMJPopupViewController"
 #define kMJPopupBackgroundView @"kMJPopupBackgroundView"
+#define kKeepOnTouchOutside @"kKeepOnTouchOutside"
 #define kMJSourceViewTag 23941
 #define kMJPopupViewTag 23942
 #define kMJOverlayViewTag 23945
@@ -32,6 +33,17 @@ static NSString *MJPopupViewDismissedKey = @"MJPopupViewDismissed";
 @implementation UIViewController (MJPopupViewController)
 
 static void * const keypath = (void*)&keypath;
+
+- (BOOL)keepOnTouchOutside{
+    NSNumber *val = objc_getAssociatedObject(self, kKeepOnTouchOutside);
+    if(!val)
+        return NO;
+    return [val boolValue];
+}
+
+- (void)setKeepOnTouchOutside:(BOOL)keepOnTouchOutside{
+    objc_setAssociatedObject(self, kKeepOnTouchOutside, [NSNumber numberWithBool:keepOnTouchOutside], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
 
 - (UIViewController*)mj_popupViewController {
     return objc_getAssociatedObject(self, kMJPopupViewController);
@@ -140,7 +152,8 @@ static void * const keypath = (void*)&keypath;
     [overlayView addSubview:popupView];
     [sourceView addSubview:overlayView];
     
-    [dismissButton addTarget:self action:@selector(dismissPopupViewControllerWithanimation:) forControlEvents:UIControlEventTouchUpInside];
+    if(!self.keepOnTouchOutside)
+        [dismissButton addTarget:self action:@selector(dismissPopupViewControllerWithanimation:) forControlEvents:UIControlEventTouchUpInside];
     switch (animationType) {
         case MJPopupViewAnimationSlideBottomTop:
         case MJPopupViewAnimationSlideBottomBottom:


### PR DESCRIPTION
Now when setting ````keepOnTouchOutside```` property in the main UIViewController ````viewDidLoad```` method, the Popup will stay on screen event the the user taps outside its bounds.
Updated Podspec file to version "0.4.1"